### PR TITLE
feat: provide standard way to register INavigation using VContainer integration

### DIFF
--- a/Viewigation.Unity/Runtime/Navigation/NavigationBuildingContext.cs
+++ b/Viewigation.Unity/Runtime/Navigation/NavigationBuildingContext.cs
@@ -63,6 +63,12 @@ namespace Viewigation.Navigation
 
       return this;
     }
+
+    public void Register(IContainerBuilder builder, Lifetime lifetime = Lifetime.Singleton)
+    {
+      var context = this;
+      builder.Register(_ => context.Create(), lifetime);
+    }
 #endif
 
     public NavigationBuildingContext WithCustomRouteFactory(IRouteFactory routeFactory)


### PR DESCRIPTION
Using `Func` factory registration is preferable since `RegisterInstance` in `VContainer` bypasses lifecycle management, meaning `INavigation.Dispose()` won't be invoked automatically. 

New method `Register` encapsulates the preferable way. 